### PR TITLE
fix splashscreen hide in cordova-app template

### DIFF
--- a/create-app/templates/common/cordova-app.js
+++ b/create-app/templates/common/cordova-app.js
@@ -4,9 +4,9 @@ var cordovaApp = {
   This method hides splashscreen after 2 seconds
   */
   handleSplashscreen: function() {
-    if (!window.navigator.splashscreen) return;
+    if (!navigator.splashscreen) return;
     setTimeout(() => {
-      window.navigator.splashscreen.hide();
+      navigator.splashscreen.hide();
     }, 2000);
   },
   /*


### PR DESCRIPTION
According to the example code in [cordova docs](https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/#preferences) and my experience (in Android) the splash instance is accessible via navigator.splashscreen. Even though window.navigator should reference the navigator object - it works this way.