### PR TITLE
workaround swiper 'fs' require, when used with f7-vue and lazy modules

### DIFF
--- a/create-app/templates/generate-webpack-config.js
+++ b/create-app/templates/generate-webpack-config.js
@@ -87,6 +87,9 @@ module.exports = (options) => {
           '@': resolvePath('src'),
         },
       },
+      node: {
+        fs: 'empty'
+      },
       devtool: env === 'production' ? ${productionDevtool} : ${developmentDevtool},
       devServer: {
         hot: true,


### PR DESCRIPTION
Webpack build fails, when f7-vue, lazy module loading used with swiper component.
This PR is intended to workaround this problem.