### PR TITLE
Android backbutton closes searchbar and card-expandable in ".page-previous"

### DIFF
--- a/create-app/templates/common/cordova-app.js
+++ b/create-app/templates/common/cordova-app.js
@@ -60,8 +60,14 @@ var cordovaApp = {
         return false;
       }
 
-      if($('.searchbar-enabled').length){
+      if($('.page-current .searchbar-enabled').length){
         f7.searchbar.disable();
+        e.preventDefault();
+        return false;
+      }
+      
+      if($('.page-current .card-expandable.card-opened').length){
+        f7.card.close('.card-opened');
         e.preventDefault();
         return false;
       }


### PR DESCRIPTION
After navigate between pages, since the ".page-previous" element is still in DOM, current handleAndroidBackButton function could take effect on elements such as Searchbar, Expandable Cards in ".page-previous".

I think it can be solved adding a ".page-current" selector. For example:

if($('.page-current .searchbar-enabled').length){
f7.searchbar.disable();
e.preventDefault();
return false;
}
if($('.page-current .card-expandable.card-opened').length){
f7.card.close('.card-opened');
e.preventDefault();
return false;
}