### PR TITLE
typo

### DIFF
--- a/create/templates/react/generate-scripts.js
+++ b/create/templates/react/generate-scripts.js
@@ -41,7 +41,7 @@ module.exports = (options) => {
     // Import App Component
     import App from '../components/app.jsx';
 
-    // Init F7 Vue Plugin
+    // Init F7 React Plugin
     Framework7.use(Framework7React)
 
     // Mount React App


### PR DESCRIPTION
Hello,

It seems a typo needs to be updated.

File path:  **framework7-cli/create/templates/react/generate-scripts.js**

```javascript
// Init F7 Vue Plugin
```

I think it should be:

```javascript
// Init F7 React Plugin
```

Best Regards,
Peter 

