### PR TITLE
Back button on Android could close the wrong popup

### DIFF
--- a/create/templates/common/cordova-app.js
+++ b/create/templates/common/cordova-app.js
@@ -41,16 +41,19 @@ var cordovaApp = {
         e.preventDefault();
         return false;
       }
-      if ($('.popup.modal-in').length) {
-        if ($('.popup.modal-in>.view').length) {
-          const currentView = f7.views.get('.popup.modal-in>.view');
+      const popups = $('.popup.modal-in');
+      if (popups.length) {
+        const popup = popups[popups.length - 1];
+        const view = popup.querySelector('.view');
+        if (view) {
+          const currentView = f7.views.get(view);
           if (currentView && currentView.router && currentView.router.history.length > 1) {
             currentView.router.back();
             e.preventDefault();
             return false;
           }
         }
-        f7.popup.close('.popup.modal-in');
+        f7.popup.close(popup);
         e.preventDefault();
         return false;
       }


### PR DESCRIPTION
Before, the code was checking if there was a popup opened, and then was checking if a popup had a view inside.
But it was not checking if the view was inside the frontest popup ; so it sometimes routes back a "behind" popup.
Additionally, the closed popup / the back routed view was the most behind and not the most in front. 
With this code, it always acts on the visible popup.