### PR TITLE
webpack5 dep update optimize-css-assets-webpack-plugin -> css-minimizer-webpack-plugin

### DIFF
--- a/create/templates/generate-webpack-config.js
+++ b/create/templates/generate-webpack-config.js
@@ -47,7 +47,7 @@ module.exports = (options) => {
     const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
     `)}
     const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-    const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin');
+    const OptimizeCSSPlugin = require('css-minimizer-webpack-plugin');
     const TerserPlugin = require('terser-webpack-plugin');
     ${templateIf(type.indexOf('pwa') >= 0, () => `
     const WorkboxPlugin = require('workbox-webpack-plugin');

--- a/create/utils/generate-package-json.js
+++ b/create/utils/generate-package-json.js
@@ -55,7 +55,7 @@ module.exports = function generatePackageJson(options) {
       'file-loader',
       'html-webpack-plugin',
       'mini-css-extract-plugin',
-      'optimize-css-assets-webpack-plugin',
+      'css-minimizer-webpack-plugin',
       'ora',
       'postcss-loader',
       'postcss-preset-env',


### PR DESCRIPTION
webpack5 dep update `optimize-css-assets-webpack-plugin -> css-minimizer-webpack-plugin`

`optimize-css-assets-webpack-plugin` doesn't support webpack version 5 says
"please use `css-minimizer-webpack-plugin` instead"

It creates a constraint
```
"peerDependencies": {
  "webpack": "^4.0.0"
}
```

Which breaks with webpack5 and babel dependencies

Full error stack in issue
https://github.com/framework7io/framework7-cli/issues/129

This patch resolve said issue, a project is created and runs properly in dev mode
It fails to build 
```
ValidationError: Invalid options object. Css Minimizer Plugin has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'cssProcessorOptions'. These properties are valid:
   object { test?, include?, exclude?, sourceMap?, minimizerOptions?, cache?, cacheKeys?, parallel?, warningsFilter?, minify? }
```
(was naive and hopeful it's a change in place compatible replacment)