### PR TITLE
Update to grab electron@latest specifically

### DIFF
--- a/create/templates/create-cordova.js
+++ b/create/templates/create-cordova.js
@@ -101,7 +101,7 @@ module.exports = (options) => {
 
     // Add cordova platforms
     const platforms = cordova.platforms.map((platform) => {
-      return platform === 'ios' ? 'ios@latest' : platform;
+      return platform === 'ios' ? 'ios@latest' : 'electron' ? 'electron@latest' : platform;
     });
     try {
       if (!isRunningInCwd) {


### PR DESCRIPTION
On an M1 Mac (arm64) running MacOS Monterrey (12.0.1) adding the electron platform would fail with a message saying "Failed to fetch platform cordova-electron@^1.1.1"

The error further down says "Error: GET https://github.com/electron/electron/releases/download/v4.2.12/electron-v4.2.12-darwin-arm64.zip returned 404"

Adding the "@latest" to the "cordova platform add electron" command fixes this issue.