### PR TITLE
Remove gap from CSP

### DIFF
--- a/create/templates/generate-index.js
+++ b/create/templates/generate-index.js
@@ -90,14 +90,14 @@ module.exports = (options) => {
 <head>
   <meta charset="utf-8">
   <!--
-  Customize this policy to fit your own app's needs. For more guidance, see:
-      https://github.com/apache/cordova-plugin-whitelist/blob/master/README.md#content-security-policy
+  Customize this policy to fit your own app's needs. For more guidance, please refer to the docs:
+      https://cordova.apache.org/docs/en/latest/
   Some notes:
     * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
     * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
       * Enable inline JS: add 'unsafe-inline' to default-src
   -->
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: content:">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, viewport-fit=cover">
 
   <meta name="theme-color" content="${documentThemeColor}">


### PR DESCRIPTION
In the recent release of Cordova CLI 11.0.0 the newest App Hello World template 6.0.0 is used for all new projects, in which the `gap:` (which was needed when using UIWebView on iOS) from the Content Security Policy has been completely removed.

So I thought of making the same change in Framework7 CLI in the file generate-index.js