### PR TITLE
include ios / md fonts via vite

### DIFF
--- a/create/templates/copy-assets.js
+++ b/create/templates/copy-assets.js
@@ -34,8 +34,8 @@ module.exports = (options, iconFile) => {
   if (framework === 'vue') toCopy.push(...copyVueAssets(options));
   if (framework === 'react') toCopy.push(...copyReactAssets(options));
   if (framework === 'svelte') toCopy.push(...copySvelteAssets(options));
-
-  if (theming.iconFonts) {
+  
+  if (theming.iconFonts && framework !== 'svelte') {
     // Copy Icons CSS
     toCopy.push({
       from: path.resolve(__dirname, 'common', 'css', 'icons.css'),

--- a/create/templates/svelte/generate-scripts.js
+++ b/create/templates/svelte/generate-scripts.js
@@ -27,7 +27,10 @@ module.exports = (options) => {
 
     // Import Icons and App Custom Styles
     ${templateIf(theming.iconFonts, () => `
-    import '../css/icons.css';
+    // Framework7 Icons Font (for iOS theme)
+    import 'framework7-icons/css/framework7-icons.css';
+    // Material Icons Font (for MD theme) 
+    import 'material-icons/iconfont/filled.css'
     `)}
     import '../css/app.${stylesExtension(cssPreProcessor)}';
 

--- a/create/utils/generate-package-json.js
+++ b/create/utils/generate-package-json.js
@@ -59,7 +59,7 @@ module.exports = function generatePackageJson(options) {
     }
   }
 
-  if (theming.iconFonts || (framework === 'core' && !bundler)) {
+  if ((theming.iconFonts && framework !== 'svelte') || (framework === 'core' && !bundler)) {
     devDependencies.push('cpy-cli');
   }
 
@@ -71,7 +71,7 @@ module.exports = function generatePackageJson(options) {
 
   const postInstall = [];
 
-  if (theming.iconFonts) {
+  if (theming.iconFonts && framework !== 'svelte') {
     postInstall.push(
       ...[
         `cpy --flat ./node_modules/framework7-icons/fonts/*.* ./${bundler ? 'src' : 'www'}/fonts/`,


### PR DESCRIPTION
Current implementation of adding fonts for svelte includes manually copying the fonts to the source folder. 

With vite this is not necessary as it can be automated. As such we can drop bothe file: `icons.css` file and dependency `cpy-cli`. For `svelte` it works just fine - so it might be possible to extend this patch to `vue` and `react`, too.

Note: As far as I could tell only the "regular" (filled) variant of material-icons` is required to support the framework7 md theme.